### PR TITLE
Add workflow to build dev_blog

### DIFF
--- a/.github/workflows/blog_build.yml
+++ b/.github/workflows/blog_build.yml
@@ -1,0 +1,36 @@
+name: Build and deploy blog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'source/**'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Build site
+        run: python scripts/build.py
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dev_blog
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: rebuild dev blog" && git push
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to rebuild the blog whenever `source/` changes

## Testing
- `python scripts/build.py && ls dev_blog | head`


------
https://chatgpt.com/codex/tasks/task_e_6847c5ffe4448325bc3a8d74858d2880