### PR TITLE
Fix gitignore so HTML output can be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Build output directory
-dev_blog/*
-!dev_blog/image/
-!dev_blog/image/**
+# Allow dev_blog/ HTML output to be committed while ignoring temporary cache
+dev_blog/cache/
 
 # Temporary or cache directories generated during builds
 cache/


### PR DESCRIPTION
## Summary
- allow dev_blog HTML output to be staged
- still ignore any cache files under dev_blog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847deab7c148325ad6db945df644ba7