### PR TITLE
Fix extended section toggle

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -179,7 +179,7 @@ def render_entry_block(entry: dict, anchor_id: str, next_anchor: str | None):
     if entry["extended"]:
         ext_id = f"ext-{hash(date_str + title)}"
         ext_html = (
-            f'<a href="javascript:void(0);" onclick="toggle(\"{ext_id}\")">&#9660;追記を開く&#9660;</a>'
+            f'<a href="javascript:void(0);" onclick="toggle(\'{ext_id}\')">　&#9660;追記を開く&#9660;</a>'
             f'<div id="{ext_id}" style="display:none;">{extended}</div>'
         )
 


### PR DESCRIPTION
## Summary
- ensure quotes correctly wrap extended section IDs
- add full-width space before `▼追記を開く▼`

## Testing
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68484d48185883258c47ac21265ed640