### PR TITLE
Fix build whitespace & add future-date filtering

### DIFF
--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -1,0 +1,34 @@
+name: Scheduled blog build
+
+on:
+  schedule:
+    - cron: '0 0 * * 6'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Build site
+        run: python scripts/build.py
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: scheduled rebuild" && git push
+          fi

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,6 +1,6 @@
 import os
 import glob
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 import html
 import json
@@ -79,8 +79,8 @@ def parse_entries(source_dir: str = "source_txt"):
                     "category": category,
                     "date": date,
                     "date_str": date_str,
-                    "body": "\n".join(body_lines).strip(),
-                    "extended": "\n".join(extended_lines).strip(),
+                    "body": "\n".join(body_lines).rstrip(),
+                    "extended": "\n".join(extended_lines).rstrip(),
                 }
             )
     return entries
@@ -293,7 +293,10 @@ def assemble_full_page(title: str, body_html: str, header_tpl: str, footer_tpl: 
 # =============================
 
 def build():
-    entries = [e for e in parse_entries() if e.get('date')]
+    all_entries = [e for e in parse_entries() if e.get('date')]
+    jst = timezone(timedelta(hours=9))
+    now_jst = datetime.now(jst).replace(tzinfo=None)
+    entries = [e for e in all_entries if e['date'] <= now_jst]
     entries.sort(key=lambda e: e['date'])  # oldest → newest
 
     # Load shared header & footer (required)


### PR DESCRIPTION
## Summary
- keep leading spaces in body & extended blocks
- ignore posts dated in the future (JST)
- add scheduled build workflow running 9AM JST Saturdays

## Testing
- `python -m py_compile scripts/build.py`
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_684904574a688325b444ba777fd9c742