### PR TITLE
Insert header into content section

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -269,10 +269,13 @@ def render_sidebar(all_months: list[tuple[str, str]],
 # Full page assembler
 # =============================
 
-def render_body(title: str, content: str, sidebar_html: str, navigation: str) -> str:
+def render_body(title: str, content: str, sidebar_html: str, navigation: str,
+                header_in_content: str) -> str:
     """Return the HTML to be placed inside <body>."""
     body_parts = [STYLE_BLOCK, SCRIPT_BLOCK]
     body_parts.append("<div id='content'>")
+    body_parts.append(header_in_content)
+    body_parts.append("")
     body_parts.append(f"<div class='nav'>{navigation}</div>")
     body_parts.append(content)
     body_parts.append(f"<div class='nav'>{navigation}</div>")
@@ -304,6 +307,8 @@ def build():
         HEADER_TEMPLATE = f.read()
     with open(os.path.join('design', 'footer.txt'), encoding='utf-8') as f:
         FOOTER_TEMPLATE = f.read()
+    with open(os.path.join('design', 'header_in_content.txt'), encoding='utf-8') as f:
+        HEADER_IN_CONTENT = f.read()
 
     root = 'docs'
     ensure_dir(root)
@@ -382,7 +387,7 @@ def build():
         entry_html = '<br><br><br>\n'.join(blocks)
 
         sidebar = render_sidebar(months_sorted, cat_counts, page_dir, root, month_counts, cat_dir_map)
-        body_html = render_body(f'{year}-{month}', entry_html, sidebar, navigation)
+        body_html = render_body(f'{year}-{month}', entry_html, sidebar, navigation, HEADER_IN_CONTENT)
         full_html = assemble_full_page(f'{year}-{month}', body_html, HEADER_TEMPLATE, FOOTER_TEMPLATE)
         write_file(page_path, full_html)
 
@@ -418,7 +423,7 @@ def build():
                 blocks.append(render_entry_block(ent, ent['anchor_id'], next_id))
             entry_html = '<br><br><br>\n'.join(blocks)
             sidebar = render_sidebar(months_sorted, cat_counts, page_dir, root, month_counts, cat_dir_map)
-            body_html = render_body(cat or 'uncategorized', entry_html, sidebar, navigation)
+            body_html = render_body(cat or 'uncategorized', entry_html, sidebar, navigation, HEADER_IN_CONTENT)
             full_html = assemble_full_page(cat or 'uncategorized', body_html, HEADER_TEMPLATE, FOOTER_TEMPLATE)
             write_file(page_path, full_html)
 
@@ -459,7 +464,7 @@ def build():
             blocks.append(render_entry_block(ent, ent['anchor_id'], next_id))
         entry_html = '<br><br><br>\n'.join(blocks)
         sidebar = render_sidebar(months_sorted, cat_counts, page_dir, root, month_counts, cat_dir_map)
-        body_html = render_body('開発日誌', entry_html, sidebar, navigation)
+        body_html = render_body('開発日誌', entry_html, sidebar, navigation, HEADER_IN_CONTENT)
         full_html = assemble_full_page('開発日誌', body_html, HEADER_TEMPLATE, FOOTER_TEMPLATE)
         write_file(page_path, full_html)
 


### PR DESCRIPTION
## Summary
- load `header_in_content.txt` and pass to `render_body`
- insert the loaded snippet after `<div id='content'>` in every generated page

## Testing
- `python3 -m py_compile scripts/build.py`
- `python3 scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68490e3488848325a705bfc4da1508ac