### PR TITLE
Add article position indicator above navigation

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -285,14 +285,19 @@ def render_sidebar(all_months: list[tuple[str, str]],
 # =============================
 
 def render_body(title: str, content: str, sidebar_html: str, navigation: str,
-                header_in_content: str, footer_end_content: str) -> str:
+                header_in_content: str, footer_end_content: str,
+                article_pos: str = "") -> str:
     """Return the HTML to be placed inside <body>."""
     body_parts = [STYLE_BLOCK, SCRIPT_BLOCK]
     body_parts.append("<div id='content'>")
     body_parts.append(header_in_content)
     body_parts.append("")
+    if article_pos:
+        body_parts.append(f"<div class='article_pos'>{html.escape(article_pos)}</div>")
     body_parts.append(f"<div class='nav'>{navigation}</div>")
     body_parts.append(content)
+    if article_pos:
+        body_parts.append(f"<div class='article_pos'>{html.escape(article_pos)}</div>")
     body_parts.append(f"<div class='nav'>{navigation}</div>")
     body_parts.append("<a id='bottom'></a>")
     body_parts.append(footer_end_content)
@@ -419,6 +424,7 @@ def build():
             navigation,
             HEADER_IN_CONTENT,
             FOOTER_END_CONTENT,
+            f'{year}年{month}月',
         )
         full_html = assemble_full_page(f'{year}-{month}', body_html, HEADER_TEMPLATE, FOOTER_TEMPLATE)
         write_file(page_path, full_html)
@@ -455,6 +461,8 @@ def build():
                 blocks.append(render_entry_block(ent, ent['anchor_id'], next_id))
             entry_html = '<br><br><br>\n'.join(blocks)
             sidebar = render_sidebar(months_sorted, cat_counts, page_dir, root, month_counts, cat_dir_map, recent_entries)
+            total_pages = (len(es_sorted) + 9) // 10
+            pos_text = f"{cat or 'uncategorized'} {page_num}/{total_pages}"
             body_html = render_body(
                 cat or 'uncategorized',
                 entry_html,
@@ -462,6 +470,7 @@ def build():
                 navigation,
                 HEADER_IN_CONTENT,
                 FOOTER_END_CONTENT,
+                pos_text,
             )
             full_html = assemble_full_page(cat or 'uncategorized', body_html, HEADER_TEMPLATE, FOOTER_TEMPLATE)
             write_file(page_path, full_html)
@@ -510,6 +519,7 @@ def build():
             navigation,
             HEADER_IN_CONTENT,
             FOOTER_END_CONTENT,
+            'トップ',
         )
         full_html = assemble_full_page('開発日誌', body_html, HEADER_TEMPLATE, FOOTER_TEMPLATE)
         # Insert no-cache meta tags only on the top index page


### PR DESCRIPTION
## Summary
- update `render_body` to insert article position text above navigation
- show current section info for monthly, category, and top pages

## Testing
- `python -m py_compile scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_6849a11a179083259b0a9a74675a951b